### PR TITLE
EventDateTime fix staging urls, add AbsoluteLink function

### DIFF
--- a/src/EventDateTime.php
+++ b/src/EventDateTime.php
@@ -42,7 +42,7 @@ class EventDateTime extends DataObject
 		'EndTime' => ''
 	];
 
-	public function populateDefaults() 
+	public function populateDefaults()
 	{
 		$today = date('m/d/Y');
 		$this->StartDate = $today;
@@ -86,11 +86,11 @@ class EventDateTime extends DataObject
 		//$existingDT = $this->Event->EventDateTimes()->filter($filter);
 		//var_dump($eventDateTimes);
 		//die();
-		
+
 		//if(sizeof($existingDT) > 0) $result->addError('Conflict with existing Occurrence, please choose another Date and Time');
 
 		//$result->addError('Conflict with existing Occurrence - Number: ' . sizeof($existingDT));
-		
+
 
 		return $result;
 
@@ -114,16 +114,23 @@ class EventDateTime extends DataObject
 	{
 
 		$controller = CalendarPage::get()->filter(['ID' => $this->Event->CalendarID])->first();
-		$link = Controller::join_links(Director::baseURL(), $controller->Link('event'), '/' . $this->Event->URLSegment);
 
-		$link .= '/' . $this->StartDate;
+		$urlsegment_with_date = $this->Event->URLSegment . '/' . $this->StartDate;
 
 		if($this->AllDay == 0){
-		$dateString = strtotime($this->StartDate . ' ' . $this->StartTime);
-			$link .= '/' . date('Hi', $dateString);
+			$date_string = strtotime($this->StartDate . ' ' . $this->StartTime);
+			$urlsegment_with_date .= '/' . date('Hi', $date_string);
 		}
+
+		$link = Controller::join_links(Director::baseURL(), $controller->Link('event'), '/' . $urlsegment_with_date);
+
 		return $link;
-	}	
+	}
+
+	public function AbsoluteLink($action = null)
+	{
+		return Director::absoluteURL($this->Link($action));
+	}
 
 	public function getCMSFields()
 	{


### PR DESCRIPTION
- Fixed `?stage=Stage` breaking EventDateTime URLs.
- Added `AbsoluteLink` function to EventDateTime for use where absolute paths are preferable to relative ones.